### PR TITLE
fix base64 issue with cucumberjs 10+

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -49,7 +49,7 @@ function generateReport(options) {
 
   if (!options.reportPath) {
     throw new Error(
-      'An output path for the reports should be defined, no path was provided.'
+      'An output path for the reports should be defined, no path was provided.',
     );
   }
 
@@ -125,27 +125,27 @@ function generateReport(options) {
   // Percentages
   suite.featureCount.ambiguousPercentage = _calculatePercentage(
     suite.featureCount.ambiguous,
-    suite.featureCount.total
+    suite.featureCount.total,
   );
   suite.featureCount.failedPercentage = _calculatePercentage(
     suite.featureCount.failed,
-    suite.featureCount.total
+    suite.featureCount.total,
   );
   suite.featureCount.notDefinedPercentage = _calculatePercentage(
     suite.featureCount.notDefined,
-    suite.featureCount.total
+    suite.featureCount.total,
   );
   suite.featureCount.pendingPercentage = _calculatePercentage(
     suite.featureCount.pending,
-    suite.featureCount.total
+    suite.featureCount.total,
   );
   suite.featureCount.skippedPercentage = _calculatePercentage(
     suite.featureCount.skipped,
-    suite.featureCount.total
+    suite.featureCount.total,
   );
   suite.featureCount.passedPercentage = _calculatePercentage(
     suite.featureCount.passed,
-    suite.featureCount.total
+    suite.featureCount.total,
   );
 
   /**
@@ -164,7 +164,7 @@ function generateReport(options) {
     jsonFile.writeFileSync(
       path.resolve(reportPath, 'enriched-output.json'),
       suite,
-      { spaces: 2 }
+      { spaces: 2 },
     );
   }
 
@@ -174,13 +174,13 @@ function generateReport(options) {
   /* istanbul ignore else */
   if (!disableLog) {
     console.log(
-        '\x1b[34m%s\x1b[0m',
-        `\n
+      '\x1b[34m%s\x1b[0m',
+      `\n
 =====================================================================================
     Multiple Cucumber HTML report generated in:
 
     ${path.join(reportPath, INDEX_HTML)}
-=====================================================================================\n`
+=====================================================================================\n`,
     );
   }
 
@@ -259,51 +259,51 @@ function generateReport(options) {
       // Percentages
       feature.scenarios.ambiguousPercentage = _calculatePercentage(
         feature.scenarios.ambiguous,
-        feature.scenarios.total
+        feature.scenarios.total,
       );
       feature.scenarios.failedPercentage = _calculatePercentage(
         feature.scenarios.failed,
-        feature.scenarios.total
+        feature.scenarios.total,
       );
       feature.scenarios.notDefinedPercentage = _calculatePercentage(
         feature.scenarios.notDefined,
-        feature.scenarios.total
+        feature.scenarios.total,
       );
       feature.scenarios.passedPercentage = _calculatePercentage(
         feature.scenarios.passed,
-        feature.scenarios.total
+        feature.scenarios.total,
       );
       feature.scenarios.pendingPercentage = _calculatePercentage(
         feature.scenarios.pending,
-        feature.scenarios.total
+        feature.scenarios.total,
       );
       feature.scenarios.skippedPercentage = _calculatePercentage(
         feature.scenarios.skipped,
-        feature.scenarios.total
+        feature.scenarios.total,
       );
       suite.scenarios.ambiguousPercentage = _calculatePercentage(
         suite.scenarios.ambiguous,
-        suite.scenarios.total
+        suite.scenarios.total,
       );
       suite.scenarios.failedPercentage = _calculatePercentage(
         suite.scenarios.failed,
-        suite.scenarios.total
+        suite.scenarios.total,
       );
       suite.scenarios.notDefinedPercentage = _calculatePercentage(
         suite.scenarios.notDefined,
-        suite.scenarios.total
+        suite.scenarios.total,
       );
       suite.scenarios.passedPercentage = _calculatePercentage(
         suite.scenarios.passed,
-        suite.scenarios.total
+        suite.scenarios.total,
       );
       suite.scenarios.pendingPercentage = _calculatePercentage(
         suite.scenarios.pending,
-        suite.scenarios.total
+        suite.scenarios.total,
       );
       suite.scenarios.skippedPercentage = _calculatePercentage(
         suite.scenarios.skipped,
-        suite.scenarios.total
+        suite.scenarios.total,
       );
     });
   }
@@ -335,7 +335,7 @@ function generateReport(options) {
       if (scenario.hasOwnProperty('description') && scenario.description) {
         scenario.description = scenario.description.replace(
           new RegExp('\r?\n', 'g'),
-          '<br />'
+          '<br />',
         );
       }
 
@@ -408,6 +408,7 @@ function generateReport(options) {
         step.attachments = [];
         step.embeddings.forEach((embedding, embeddingIndex) => {
           /* istanbul ignore else */
+          embedding.data = atob(embedding.data);
           if (
             embedding.mime_type === 'application/json' ||
             (embedding.media && embedding.media.type === 'application/json')
@@ -456,11 +457,11 @@ function generateReport(options) {
       if (step.doc_string !== undefined) {
         step.id = `${uuid()}.${scenario.id}.${step.name}`.replace(
           /[^a-zA-Z0-9-_]/g,
-          '-'
+          '-',
         );
         step.restWireData = _escapeHtml(step.doc_string.value).replace(
           new RegExp('\r?\n', 'g'),
-          '<br />'
+          '<br />',
         );
       }
 
@@ -522,7 +523,7 @@ function generateReport(options) {
       } catch (err) {
         return fs.readFileSync(
           path.join(__dirname, '..', 'templates', fileName),
-          'utf-8'
+          'utf-8',
         );
       }
     } else {
@@ -540,7 +541,7 @@ function generateReport(options) {
     return typeof string === 'string' || string instanceof String
       ? string.replace(
           /[^0-9A-Za-z ]/g,
-          (chr) => '&#' + chr.charCodeAt(0) + ';'
+          (chr) => '&#' + chr.charCodeAt(0) + ';',
         )
       : string;
   }
@@ -568,13 +569,13 @@ function generateReport(options) {
       _.template(_readTemplateFile(FEATURES_OVERVIEW_INDEX_TEMPLATE))({
         suite: suite,
         featuresOverview: _.template(
-          _readTemplateFile(FEATURES_OVERVIEW_TEMPLATE)
+          _readTemplateFile(FEATURES_OVERVIEW_TEMPLATE),
         )({
           suite: suite,
           _: _,
         }),
         featuresScenariosOverviewChart: _.template(
-          _readTemplateFile(SCENARIOS_OVERVIEW_CHART_TEMPLATE)
+          _readTemplateFile(SCENARIOS_OVERVIEW_CHART_TEMPLATE),
         )({
           overviewPage: true,
           scenarios: suite.scenarios,
@@ -584,10 +585,10 @@ function generateReport(options) {
           {
             suite: suite,
             _: _,
-          }
+          },
         ),
         featuresOverviewChart: _.template(
-          _readTemplateFile(FEATURES_OVERVIEW_CHART_TEMPLATE)
+          _readTemplateFile(FEATURES_OVERVIEW_CHART_TEMPLATE),
         )({
           suite: suite,
           _: _,
@@ -599,7 +600,7 @@ function generateReport(options) {
         pageTitle: pageTitle,
         reportName: reportName,
         pageFooter: pageFooter,
-      })
+      }),
     );
   }
 
@@ -617,7 +618,7 @@ function generateReport(options) {
     suite.features.forEach((feature) => {
       const featurePage = path.resolve(
         reportPath,
-        `${FEATURE_FOLDER}/${feature.id}.html`
+        `${FEATURE_FOLDER}/${feature.id}.html`,
       );
       fs.writeFileSync(
         featurePage,
@@ -625,7 +626,7 @@ function generateReport(options) {
           feature: feature,
           suite: suite,
           featureScenariosOverviewChart: _.template(
-            _readTemplateFile(SCENARIOS_OVERVIEW_CHART_TEMPLATE)
+            _readTemplateFile(SCENARIOS_OVERVIEW_CHART_TEMPLATE),
           )({
             overviewPage: false,
             feature: feature,
@@ -634,7 +635,7 @@ function generateReport(options) {
             _: _,
           }),
           featureMetadataOverview: _.template(
-            _readTemplateFile(FEATURE_METADATA_OVERVIEW_TEMPLATE)
+            _readTemplateFile(FEATURE_METADATA_OVERVIEW_TEMPLATE),
           )({
             metadata: feature.metadata,
             _: _,
@@ -652,7 +653,7 @@ function generateReport(options) {
           reportName: reportName,
           pageFooter: pageFooter,
           plainDescription: plainDescription,
-        })
+        }),
       );
       // Copy the assets, but first check if they don't exist and not useCDN
       if (
@@ -662,9 +663,9 @@ function generateReport(options) {
         fs.copySync(
           path.resolve(
             path.dirname(require.resolve('../package.json')),
-            'templates/assets'
+            'templates/assets',
           ),
-          path.resolve(reportPath, 'assets')
+          path.resolve(reportPath, 'assets'),
         );
       }
     });
@@ -680,7 +681,7 @@ function generateReport(options) {
    */
   function formatDuration(duration) {
     return Duration.fromMillis(
-        durationInMS ? duration : duration / 1000000
+      durationInMS ? duration : duration / 1000000,
     ).toFormat('hh:mm:ss.SSS');
   }
 }


### PR DESCRIPTION
linked to #298


Describe the bug
In the JSON formatter output of multiple-cucumber-html-reporter, all attachments, including those initially attached as plain text strings, are now Base64 encoded. This uniform encoding approach leads to ambiguity for consumers of the report, as they cannot distinguish whether an attachment was originally a plain text string or a different file format.

To Reproduce
Steps to reproduce the behavior:

just generate a report based on cucumber 10.0.1 with some attachement (json/ text / image)

Expected behavior
The expected behavior was that string attachments would remain as plain text in the JSON formatter output, while other types of attachments would be Base64 encoded. This distinction would enable consumers to easily identify the nature of the attachments without additional processing.

Additional context
To resolve this issue, a decoding mechanism such as atob(embedding.data); should be implemented to correctly decode Base64 attachments before passing them to the report. This would ensure that plain text attachments maintain their original format in the JSON output.