### PR TITLE
Decode base64-encoded Text Attachments

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -414,7 +414,7 @@ function generateReport(options) {
 	    embedding.mime_type === 'text/html' ||
 	    embedding.mime_type === 'text/plain'
 	  ) {
-	    embedding.data = Buffer.from(embedding.data, 'base64')
+	    embedding.data = Buffer.from(embedding.data.toString(), 'base64')
 	  }
 	
           /* istanbul ignore else */

--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -406,7 +406,17 @@ function generateReport(options) {
     scenario.steps.forEach((step) => {
       if (step.embeddings !== undefined) {
         step.attachments = [];
+	
         step.embeddings.forEach((embedding, embeddingIndex) => {
+	  /* Decode Base64 for Text-ish attachements */
+	  if(
+	    embedding.mime_type === 'application/json' ||
+	    embedding.mime_type === 'text/html' ||
+	    embedding.mime_type === 'text/plain'
+	  ) {
+	    embedding.data = Buffer.from(embedding.data, 'base64')
+	  }
+	
           /* istanbul ignore else */
           if (
             embedding.mime_type === 'application/json' ||


### PR DESCRIPTION
Since Cucumber 10, all Text Attachments are as well Base64 encoded, which currently makes them unreadable in the HTML-Reports.

This fix was created by @lerhum and @WasiqB.
As my customer needs this piece of code, I fixed the findings as described.
All Credits go the the creators, I just want to help speeden up things :)

# Original Text

linked to https://github.com/WasiqB/multiple-cucumber-html-reporter/issues/298

Describe the bug
In the JSON formatter output of multiple-cucumber-html-reporter, all attachments, including those initially attached as plain text strings, are now Base64 encoded. This uniform encoding approach leads to ambiguity for consumers of the report, as they cannot distinguish whether an attachment was originally a plain text string or a different file format.

To Reproduce
Steps to reproduce the behavior:

just generate a report based on cucumber 10.0.1 with some attachement (json/ text / image)

Expected behavior
The expected behavior was that string attachments would remain as plain text in the JSON formatter output, while other types of attachments would be Base64 encoded. This distinction would enable consumers to easily identify the nature of the attachments without additional processing.

Additional context
To resolve this issue, a decoding mechanism such as atob(embedding.data); should be implemented to correctly decode Base64 attachments before passing them to the report. This would ensure that plain text attachments maintain their original format in the JSON output.