### PR TITLE
Pending&Skipped status on HTML reporter

### DIFF
--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -377,10 +377,14 @@ function generateReport(options) {
       }
 
       if (scenario.skipped > 0) {
-        suite.scenarios.total++;
-        suite.scenarios.skipped++;
-        feature.scenarios.total++;
-        return feature.scenarios.skipped++;
+        suite.scenarios.total++
+        feature.scenarios.total++
+        if (scenario.pending > 0) {
+          suite.scenarios.pending++
+          return feature.scenarios.pending++
+        }
+        suite.scenarios.skipped++
+        return feature.scenarios.skipped++
       }
 
       /* istanbul ignore else */
@@ -392,7 +396,8 @@ function generateReport(options) {
       }
     });
 
-    feature.isSkipped = feature.scenarios.total === feature.scenarios.skipped;
+    feature.isPending = feature.scenarios.total === feature.scenarios.pending
+    feature.isSkipped = (feature.scenarios.total === (feature.scenarios.skipped + feature.scenarios.pending))
 
     return feature;
   }
@@ -480,6 +485,13 @@ function generateReport(options) {
           '<br />'
         );
       }
+      if (step.result.status === RESULT_STATUS.pending) {
+        return scenario.pending++
+      }
+
+      if (step.result.status === RESULT_STATUS.skipped) {
+        return scenario.skipped++
+      }
 
       if (
         !step.result ||
@@ -512,15 +524,11 @@ function generateReport(options) {
         return scenario.notDefined++;
       }
 
-      if (step.result.status.toLowerCase() === RESULT_STATUS.pending) {
-        return scenario.pending++;
-      }
-
       if (step.result.status.toLowerCase() === RESULT_STATUS.ambiguous) {
         return scenario.ambiguous++;
       }
 
-      scenario.skipped++;
+      scenario.pending++
     });
 
     return scenario;


### PR DESCRIPTION
This PR improves how multiple-cucumber-html-reporter handles pending statuses. Specifically:
    If any step in a scenario is marked as pending, the entire scenario is now correctly reported as pending instead of skipped.
    The calculation of pending scenarios and features has been fixed accordingly.
    All logic changes are implemented in generate-report.js.

✅ Fixes / Enhancements
    Accurate status classification for pending steps.
    Ensures pending scenarios are reflected correctly at both the scenario and feature level in the final HTML report.
    Improves consistency with step-level statuses.