### PR TITLE
Allow user to send search value via url query params

### DIFF
--- a/templates/components/features-overview.tmpl
+++ b/templates/components/features-overview.tmpl
@@ -13,6 +13,11 @@
         </div>
 
         <div class="x_content">
+            <div class="row" style="margin-bottom: 10px;">
+                <div class="col-md-4 col-sm-6 col-xs-12">
+                    <input id="features-search-box" type="text" class="form-control" placeholder="Search features..." autocomplete="off">
+                </div>
+            </div>
             <div class="table-responsive">
                 <table id="features-table" class="table table-striped table-bordered dt-responsive nowrap" cellspacing="0"
                        width="100%">

--- a/templates/features-overview.index.tmpl
+++ b/templates/features-overview.index.tmpl
@@ -130,10 +130,31 @@
         <!-- Custom -->
         <script>
             $(document).ready(function () {
-                $('#features-table').dataTable({
+                // Get search param from querystring
+                function getQueryParam(name) {
+                    const urlParams = new URLSearchParams(window.location.search);
+                    return urlParams.get(name) || '';
+                }
+
+                var searchValue = getQueryParam('search');
+                if (searchValue) {
+                    $('#features-search-box').val(searchValue);
+                }
+
+                var table = $('#features-table').DataTable({
                     "order": [[0, "asc"]],
                     "lengthMenu": [[50, 100, 150, -1], [50, 100, 150, "All"]],
                     "stateSave": true
+                });
+
+                // If search param exists, filter table
+                if (searchValue) {
+                    table.search(searchValue).draw();
+                }
+
+                // Live search as user types
+                $('#features-search-box').on('input', function() {
+                    table.search(this.value).draw();
                 });
 
                 var featureOptions = {


### PR DESCRIPTION
We have a need/desire to be able to link from confluence and jira to specific features/scenarios via tags.  The reporter currently supports searching via tag, but didn't support passing in default values for that search box via a URL query param.  For example: multiple-cucumber-html-reporter/.tmp/browsers/index.html?search=test

This PR adds simple support for this.