### PR TITLE
Fixing the parallel execution duration issue 440

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,20 @@ This expects the durations in the report to be in **nanoseconds**, which might r
 If set to `true` the duration of steps will be expected to be in **milliseconds**, which might result in incorrect durations when using a version of Cucumber(JS 1 or 4) that does report in **nanoseconds**.
 This parameter relies on `displayDuration: true`
 
+### `durationAggregation`
+
+- **Type:** `string`
+- **Default:** `sum`
+- **Mandatory:** No
+- **Possible values:** `sum | wallClock`
+
+Controls how feature duration is calculated when `displayDuration: true`.
+
+- `sum`: sum all scenario durations in a feature (default)
+- `wallClock`: use elapsed wall-clock time (`latest scenario end - earliest scenario start`)
+
+For `wallClock`, each timed scenario must provide `start_timestamp`; otherwise the reporter safely falls back to summed duration for that feature.
+
 ### `hideMetadata`
 
 - **Type:** `boolean`

--- a/lib/generate-report.js
+++ b/lib/generate-report.js
@@ -67,6 +67,8 @@ function generateReport(options) {
   const displayDuration = !!options.displayDuration;
   const displayReportTime = !!options.displayReportTime;
   const durationInMS = !!options.durationInMS;
+  const durationAggregation =
+    options.durationAggregation === 'wallClock' ? 'wallClock' : 'sum';
   const hideMetadata = !!options.hideMetadata;
   const pageTitle = options.pageTitle || 'Multiple Cucumber HTML Reporter';
   const pageFooter = options.pageFooter || null;
@@ -88,6 +90,9 @@ function generateReport(options) {
     hideMetadata: hideMetadata,
     displayReportTime: displayReportTime,
     displayDuration: displayDuration,
+    durationAggregation: durationAggregation,
+    durationColumnTitle:
+      durationAggregation === 'wallClock' ? 'Duration (wall clock)' : 'Duration',
     browser: 0,
     name: '',
     version: 'version',
@@ -316,6 +321,11 @@ function generateReport(options) {
    * @private
    */
   function _parseScenarios(feature) {
+    let earliestScenarioStart = Number.POSITIVE_INFINITY;
+    let latestScenarioEnd = 0;
+    let scenarioWithDurationCount = 0;
+    let scenarioWithStartTimestampCount = 0;
+
     feature.elements.forEach((scenario) => {
       scenario.passed = 0;
       scenario.failed = 0;
@@ -329,8 +339,19 @@ function generateReport(options) {
       scenario = _parseSteps(scenario);
 
       if (scenario.duration > 0) {
+        scenarioWithDurationCount++;
         feature.duration += scenario.duration;
         scenario.time = formatDuration(scenario.duration);
+
+        if (durationAggregation === 'wallClock') {
+          const scenarioStart = parseScenarioStartTime(scenario);
+          if (scenarioStart !== null) {
+            scenarioWithStartTimestampCount++;
+            const scenarioEnd = scenarioStart + toMillis(scenario.duration);
+            earliestScenarioStart = Math.min(earliestScenarioStart, scenarioStart);
+            latestScenarioEnd = Math.max(latestScenarioEnd, scenarioEnd);
+          }
+        }
       }
 
       if (scenario.hasOwnProperty('description') && scenario.description) {
@@ -395,6 +416,15 @@ function generateReport(options) {
         return feature.scenarios.passed++;
       }
     });
+
+    if (
+      durationAggregation === 'wallClock' &&
+      scenarioWithDurationCount > 0 &&
+      scenarioWithStartTimestampCount === scenarioWithDurationCount &&
+      latestScenarioEnd > earliestScenarioStart
+    ) {
+      feature.duration = fromMillis(latestScenarioEnd - earliestScenarioStart);
+    }
 
     feature.isPending = feature.scenarios.total === feature.scenarios.pending
     feature.isSkipped = (feature.scenarios.total === (feature.scenarios.skipped + feature.scenarios.pending))
@@ -710,6 +740,38 @@ function generateReport(options) {
     return Duration.fromMillis(
         durationInMS ? duration : duration / 1000000
     ).toFormat('hh:mm:ss.SSS');
+  }
+
+  /**
+   * Convert cucumber duration to milliseconds.
+   * @param {number} duration
+   * @returns {number}
+   */
+  function toMillis(duration) {
+    return durationInMS ? duration : duration / 1000000;
+  }
+
+  /**
+   * Convert milliseconds to cucumber duration units.
+   * @param {number} millis
+   * @returns {number}
+   */
+  function fromMillis(millis) {
+    return durationInMS ? millis : millis * 1000000;
+  }
+
+  /**
+   * Parse scenario start timestamp to epoch milliseconds.
+   * @param {object} scenario
+   * @returns {number|null}
+   */
+  function parseScenarioStartTime(scenario) {
+    if (!scenario || !scenario.start_timestamp) {
+      return null;
+    }
+
+    const time = Date.parse(scenario.start_timestamp);
+    return Number.isNaN(time) ? null : time;
   }
 }
 

--- a/templates/components/features-overview-custom-metadata.tmpl
+++ b/templates/components/features-overview-custom-metadata.tmpl
@@ -25,7 +25,7 @@
                         <th><%= metadatum.name %></th>
                         <%});%>
                         <% if (suite.displayDuration) { %>
-                        <th>Duration</th>
+                        <th><%= suite.durationColumnTitle %></th>
                         <% } %>
                         <th>Total</th>
                         <th>Passed</th>

--- a/templates/components/features-overview.tmpl
+++ b/templates/components/features-overview.tmpl
@@ -44,7 +44,7 @@
                         <th>Date</th>
                         <% } %>
                         <% if (suite.displayDuration) { %>
-                        <th>Duration</th>
+                        <th><%= suite.durationColumnTitle %></th>
                         <% } %>
                         <th>Total</th>
                         <th>Passed</th>

--- a/test/unit/data/json-parallel-time/parallel_execution.json
+++ b/test/unit/data/json-parallel-time/parallel_execution.json
@@ -1,0 +1,57 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "Parallel timing feature",
+    "description": "",
+    "line": 1,
+    "id": "parallel-timing-feature",
+    "uri": "features/parallel-timing.feature",
+    "tags": [],
+    "elements": [
+      {
+        "keyword": "Scenario",
+        "type": "scenario",
+        "name": "Scenario A",
+        "line": 2,
+        "id": "parallel-timing-feature;scenario-a",
+        "start_timestamp": "2025-01-01T00:00:00.000Z",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "step a",
+            "line": 3,
+            "match": {
+              "location": "steps.js:1"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 10000000000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario",
+        "type": "scenario",
+        "name": "Scenario B",
+        "line": 5,
+        "id": "parallel-timing-feature;scenario-b",
+        "start_timestamp": "2025-01-01T00:00:05.000Z",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "step b",
+            "line": 6,
+            "match": {
+              "location": "steps.js:2"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 10000000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/test/unit/data/json-partial-parallel-time/partial_parallel_execution.json
+++ b/test/unit/data/json-partial-parallel-time/partial_parallel_execution.json
@@ -1,0 +1,56 @@
+[
+  {
+    "keyword": "Feature",
+    "name": "Partial parallel timing feature",
+    "description": "",
+    "line": 1,
+    "id": "partial-parallel-timing-feature",
+    "uri": "features/partial-parallel-timing.feature",
+    "tags": [],
+    "elements": [
+      {
+        "keyword": "Scenario",
+        "type": "scenario",
+        "name": "Scenario A",
+        "line": 2,
+        "id": "partial-parallel-timing-feature;scenario-a",
+        "start_timestamp": "2025-01-01T00:00:00.000Z",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "step a",
+            "line": 3,
+            "match": {
+              "location": "steps.js:1"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 10000000000
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Scenario",
+        "type": "scenario",
+        "name": "Scenario B",
+        "line": 5,
+        "id": "partial-parallel-timing-feature;scenario-b",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "step b",
+            "line": 6,
+            "match": {
+              "location": "steps.js:2"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 10000000000
+            }
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Feature duration in the report can be misleading for parallel executions because the existing behavior sums scenario durations.
For parallel runs, summed duration can over-report elapsed time.This PR introduces a plugin-level, backward-compatible way to support wall-clock aggregation when scenario timestamps are available.


What changed

- Added new reporter option: durationAggregation
      - sum (default, current behavior)
      - wallClock (opt-in)
- Implemented wall-clock aggregation logic in feature duration calculation:
      - Uses latest scenario end - earliest scenario start
      - Applies only when all timed scenarios in a feature have valid start_timestamp
      - Falls back to summed duration when timestamp data is incomplete/missing
- Updated Features Overview duration column title:
      - Duration for sum
      - Duration (wall clock) for wallClock
- Added/updated unit tests for:
      - wall-clock aggregation with overlapping scenarios
      - fallback behavior when timestamps are missing
      - default summed behavior remains unchanged
- Updated README with durationAggregation documentation and usage notes



Backward compatibility
No breaking change.
Default behavior remains sum.
Existing consumers are unaffected unless they explicitly set durationAggregation: 'wallClock'.


Usage example:
`report.generate({
  jsonDir: './test-results',
  reportPath: './test-results/html-report',
  displayDuration: true,
  durationAggregation: 'wallClock',
});`

Notes
wallClock requires scenario start_timestamp in the Cucumber JSON.
If timestamps are unavailable/incomplete, duration safely falls back to summed mode per feature.
