### PR TITLE
feat: add support for avif, webp and jpeg image attachments

### DIFF
--- a/reporter/src/generate-report.ts
+++ b/reporter/src/generate-report.ts
@@ -460,8 +460,12 @@ async function generateReport(options: Options) {
             (embedding.media && embedding.media.type === 'text/plain')
           ) {
             step.text = (step.text ? step.text : []).concat([_escapeHtml(embedding.data)]);
-          } else if (embedding.mime_type === 'image/png' || (embedding.media && embedding.media.type === 'image/png')) {
-            step.image = (step.image ? step.image : []).concat([`data:image/png;base64,${embedding.data}`]);
+          } else if (
+            ['image/png', 'image/avif', 'image/webp', 'image/jpeg'].includes(embedding.mime_type ?? '') ||
+            (embedding.media && ['image/png', 'image/avif', 'image/webp', 'image/jpeg'].includes(embedding.media.type))
+          ) {
+            const mimeType = embedding.mime_type ?? embedding.media?.type ?? 'image/png';
+            step.image = (step.image ? step.image : []).concat([`data:${mimeType};base64,${embedding.data}`]);
             step.embeddings![embeddingIndex] = {};
           } else if (
             embedding.mime_type === 'video/webm' ||

--- a/reporter/src/test/unit/data/embedded-array-json/failure_report_avif.json
+++ b/reporter/src/test/unit/data/embedded-array-json/failure_report_avif.json
@@ -1,0 +1,86 @@
+[
+  {
+    "description": "AVIF and other modern image format attachments should render as screenshots",
+    "elements": [
+      {
+        "description": "",
+        "id": "avif-image-support;avif-screenshot",
+        "keyword": "Scenario",
+        "line": 4,
+        "name": "AVIF screenshot",
+        "steps": [
+          {
+            "arguments": [],
+            "keyword": "Given ",
+            "line": 5,
+            "name": "a step with an avif screenshot",
+            "match": {
+              "location": "features/step_definitions/avif.steps.ts:1"
+            },
+            "result": {
+              "status": "failed",
+              "duration": 100
+            },
+            "embeddings": [
+              {
+                "data": "AAAAHGZ0eXBhdmlm",
+                "mime_type": "image/avif"
+              }
+            ]
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 6,
+            "name": "a step with a webp screenshot",
+            "match": {
+              "location": "features/step_definitions/avif.steps.ts:2"
+            },
+            "result": {
+              "status": "failed",
+              "duration": 100
+            },
+            "embeddings": [
+              {
+                "data": "UklGRiAAAABXRUJQVlA4",
+                "mime_type": "image/webp"
+              }
+            ]
+          },
+          {
+            "arguments": [],
+            "keyword": "And ",
+            "line": 7,
+            "name": "a step with a jpeg screenshot",
+            "match": {
+              "location": "features/step_definitions/avif.steps.ts:3"
+            },
+            "result": {
+              "status": "failed",
+              "duration": 100
+            },
+            "embeddings": [
+              {
+                "data": "/9j/4AAQSkZJRgABAQ==",
+                "mime_type": "image/jpeg"
+              }
+            ]
+          }
+        ],
+        "tags": [
+          {
+            "name": "@avif",
+            "line": 3
+          }
+        ],
+        "type": "scenario"
+      }
+    ],
+    "id": "avif-image-support",
+    "line": 1,
+    "keyword": "Feature",
+    "name": "AVIF image support",
+    "tags": [],
+    "uri": "features/avif.feature"
+  }
+]

--- a/reporter/src/test/unit/generate-json.spec.ts
+++ b/reporter/src/test/unit/generate-json.spec.ts
@@ -106,6 +106,27 @@ describe('generate-report.js', () => {
         .toBeTrue();
     });
 
+    it('should render avif, webp and jpeg embeddings as screenshots (img tags) not as attachments', async () => {
+      fs.removeSync(REPORT_PATH);
+      await multiCucumberHTMLReporter.generate({
+        jsonDir: './src/test/unit/data/embedded-array-json/',
+        reportName: 'Modern image format embeddings',
+        reportPath: REPORT_PATH,
+        saveCollectedJSON: true,
+      });
+
+      const enriched = fs.readJsonSync(path.join(process.cwd(), REPORT_PATH, 'enriched-output.json'));
+      const avifFeature = enriched.features.find((f: { name: string }) => f.name === 'AVIF image support');
+      const steps = avifFeature.elements[0].steps;
+      const avifStep = steps.find((s: { name: string }) => s.name === 'a step with an avif screenshot');
+      const webpStep = steps.find((s: { name: string }) => s.name === 'a step with a webp screenshot');
+      const jpegStep = steps.find((s: { name: string }) => s.name === 'a step with a jpeg screenshot');
+
+      expect(avifStep.image[0]).toContain('data:image/avif;base64,');
+      expect(webpStep.image[0]).toContain('data:image/webp;base64,');
+      expect(jpegStep.image[0]).toContain('data:image/jpeg;base64,');
+    });
+
     it('should calculate feature duration with wall clock when durationAggregation is wallClock', async () => {
       fs.removeSync(REPORT_PATH);
       await multiCucumberHTMLReporter.generate({


### PR DESCRIPTION
## Problem

When a Cucumber test framework attaches screenshots in a format other than `image/png` (e.g. `image/avif`, `image/webp`, `image/jpeg`), the reporter falls through to the generic `else` branch and pushes the embedding into `step.attachments`. The template renders these as `<object>` tags, which browsers typically do not display inline — so screenshots appear missing in the report.

## Solution

Extend the image branch in `_parseSteps` to recognise `image/avif`, `image/webp`, and `image/jpeg` alongside `image/png`. The `data:` URI now uses the actual MIME type instead of hardcoding `image/png`, so the correct `<img class="screenshot">` tag is rendered for all four formats.

## Changes

- `reporter/src/generate-report.ts`: extended the image MIME type check and made the data URI prefix dynamic
- `reporter/src/test/unit/data/embedded-array-json/failure_report_avif.json`: test fixture with avif, webp and jpeg embeddings
- `reporter/src/test/unit/generate-json.spec.ts`: new test asserting each image type populates `step.image` with the correct data URI prefix

## Testing

All 16 specs pass (`pnpm unit.test.coverage`).